### PR TITLE
Try to fix jiffy mpsc queue's panic bug when loading data from node.

### DIFF
--- a/src/queues/mpsc/jiffy.rs
+++ b/src/queues/mpsc/jiffy.rs
@@ -413,6 +413,11 @@ impl<T> Receiver<T> {
                     None => return Err(DequeueError::Empty),
                 };
 
+                // Seems that tmp_n can be empty, so return empty dequeue error.
+                if tmp_n.get_state().eq(&NodeState::Empty) {
+                    return Err(DequeueError::Empty);
+                }
+
                 // Actually load the Data from the Node
                 let data = tmp_n.load();
                 // Set the Node to being Handled to not accidentally load the


### PR DESCRIPTION
I've found that the jiffy mpsc queue would panic when tmp_n.get_state() is equal to NodeState::Empty. If that's what you've missed, I think this pr could help with the panic bug.